### PR TITLE
Fix balao cortando no canto

### DIFF
--- a/projeto/addons/controles3D/ControleFaixa3D.gd
+++ b/projeto/addons/controles3D/ControleFaixa3D.gd
@@ -257,3 +257,6 @@ func _destravar_posicao():
 		parent.axis_lock_motion_x = false
 		parent.axis_lock_motion_y = false
 		parent.axis_lock_motion_z = false
+
+func get_posicao_atual() -> int:
+	return posicao_atual

--- a/projeto/recursos/jogos/enchente/jogador/playerLane3D.gd
+++ b/projeto/recursos/jogos/enchente/jogador/playerLane3D.gd
@@ -36,6 +36,7 @@ func _input(event):
 func _process(delta):
 	sprite_agua.global_position.y = posicao_sprite_agua_original.y
 
+
 func _on_ControladorArrasta_arrastado(chave):
 	if chave == 'direita':
 		controle_faixa_3d.mover_direita()
@@ -158,6 +159,13 @@ func _on_SpriteAgua_animation_finished():
 		sprite_agua.play("Idle")
 
 func _gerar_fala_de_dano():
+	print(controle_faixa_3d.get_posicao_atual())
+	if controle_faixa_3d.get_posicao_atual() == 0:
+		BaloesDeFalha.global_position.x = -2
+	elif controle_faixa_3d.get_posicao_atual() == 1:
+		BaloesDeFalha.global_position.x = 1
+	else:
+		BaloesDeFalha.global_position.x = 2
 	randomize()
 	var rndbalao = randi() % 4 + 1
 	if rndbalao == lastrnd:


### PR DESCRIPTION
O balão aparece de lados diferentes dependendo da posição. Mas continua seguindo a personagem em uma posição fixa depois que apareceu. Então se aparecer e depois mover pro canto, vai cortar o balão de novo.